### PR TITLE
Minor fix on margin

### DIFF
--- a/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
@@ -17,7 +17,7 @@ const shortcuts: Shortcut[] = [
 
 const makeShortcut = (shortcut: Shortcut): JSX.Element => {
   return (
-    <div style={{ display: 'flex', marginLeft: '10px', marginBottom: '10px' }}>
+    <div style={{ display: 'flex', marginBottom: '10px' }}>
       <div style={{ flex: '40%' }}>
         <Chip isReadOnly>{shortcut.shortcut}</Chip>
       </div>
@@ -28,13 +28,11 @@ const makeShortcut = (shortcut: Shortcut): JSX.Element => {
 
 const GraphShortcuts = (): JSX.Element => (
   <>
-    <div style={{ margin: '10px' }}>
-      {shortcuts.map(
-        (s: Shortcut): JSX.Element => {
-          return makeShortcut(s);
-        }
-      )}
-    </div>
+    {shortcuts.map(
+      (s: Shortcut): JSX.Element => {
+        return makeShortcut(s);
+      }
+    )}
   </>
 );
 


### PR DESCRIPTION
Thanks @leandroberetta I send a minor fix to your branch to adjust the margins:

![image](https://user-images.githubusercontent.com/1662329/135590281-ace2e5a4-017e-42b7-adbf-8ca9644bd356.png)

Thanks a lot for the work and sorry for the noise, but these styles tend to get modified and as we don't have a way to automatically test them I try to check that things don't look different.

Now I guess they are aligned and the text size is similar to other tours.



